### PR TITLE
Fix a failing tests on Python 2 and Python 3

### DIFF
--- a/j5basic/DictUtils.py
+++ b/j5basic/DictUtils.py
@@ -89,9 +89,6 @@ def mapdict(thedict, keymap=None, valuemap=None):
         else:
             return dict([(keymap(key), valuemap(value)) for key, value in thedict.items()])
 
-def upperkeys(thedict):
-    return mapdict(thedict, lambda s: s if s is None else s.upper(), None)
-
 class cidict(dict):
     def __init__(self, fromdict = None):
         """constructs the cidict, optionally using another dict to do so"""

--- a/j5basic/DictUtils.py
+++ b/j5basic/DictUtils.py
@@ -68,28 +68,6 @@ def filterdict(origdict, keyset):
             newdict[key] = origdict[key]
     return newdict
 
-def subtractdicts(ldict, rdict):
-    """returns a dictionary containing those keys&values in ldict that aren't in rdict or differ from rdict"""
-    diffdict = {}
-    for key in ldict:
-        if key in rdict:
-            lvalue, rvalue = ldict[key], rdict[key]
-            # type mismatch doesn't count if both are str/unicode
-            if (type(lvalue) != type(rvalue)) and not (isinstance(lvalue, str) and isinstance(rvalue, str)):
-                diffdict[key] = lvalue
-            elif type(lvalue) != type(rvalue):
-                # handle str/unicode mismatch
-                if isinstance(lvalue, bytes): lvaluecmp = lvalue.decode('UTF-8')
-                else: lvaluecmp = lvalue
-                if isinstance(lvalue, bytes): rvaluecmp = rvalue.decode('UTF-8')
-                else: rvaluecmp = rvalue
-                if lvaluecmp != rvaluecmp:
-                    diffdict[key] = lvalue
-            elif lvalue != rvalue:
-                diffdict[key] = lvalue
-        else:
-            diffdict[key] = ldict[key]
-    return diffdict
 
 def merge_dicts(dict1, *dicts):
     """returns a dictionary consisting of all the dicts, overriding key values in the order they're passed in"""

--- a/j5basic/Formatters.py
+++ b/j5basic/Formatters.py
@@ -36,9 +36,6 @@ class StrftimeFormattedTypeMixIn(object):
 @python_2_unicode_compatible
 class StrFormattedMixIn(object):
     """Mixin for formatting with a Python % string."""
-    def __init__(self, *args, **kwargs):
-        self._re_entered = False
-
     def __str__(self):
         return self.format_str % self
 

--- a/j5basic/Formatters.py
+++ b/j5basic/Formatters.py
@@ -12,7 +12,7 @@ standard_library.install_aliases()
 from builtins import range
 from builtins import *
 from builtins import object
-from future.utils import python_2_unicode_compatible
+from future.utils import python_2_unicode_compatible, text_to_native_str
 import datetime
 import logging
 import time
@@ -25,10 +25,13 @@ class StrftimeFormattedTypeMixIn(object):
     """Mixin for formatting with a Strftime format string."""
 
     def __str__(self):
-        if isinstance(self.format_str, str):
-            # flip through into string world and back again
-            return TimeUtils.strftime(self, self.format_str.encode("UTF-8")).decode("UTF-8")
-        return TimeUtils.strftime(self, self.format_str).decode("UTF-8")
+        format_str = self.format_str
+        if isinstance(format_str, bytes):
+            format_str = format_str.decode('utf-8')
+        fstr = TimeUtils.strftime(self, text_to_native_str(format_str, "utf-8"))
+        if isinstance(fstr, bytes):
+            fstr = fstr.decode("utf-8")
+        return fstr
 
 @python_2_unicode_compatible
 class StrFormattedMixIn(object):

--- a/j5basic/Formatters.py
+++ b/j5basic/Formatters.py
@@ -40,17 +40,7 @@ class StrFormattedMixIn(object):
         self._re_entered = False
 
     def __str__(self):
-        # For some reason the IntFormatter reenters this function, causing
-        # infinite recursion. We break the recursion by calling the super method
-        # if this method is re-entered
-        if not self._re_entered:
-            try:
-                self._re_entered = True
-                return self.format_str % self
-            finally:
-                self._re_entered = False
-        else:
-            return super(StrFormattedMixIn, self).__str__()
+        return self.format_str % self
 
 class FormattedDatetime(StrftimeFormattedTypeMixIn,datetime.datetime):
     def __new__(cls,format_str,*args,**kwargs):
@@ -77,18 +67,6 @@ class FormattedDate(StrftimeFormattedTypeMixIn,datetime.date):
 class FormattedTime(StrftimeFormattedTypeMixIn,datetime.time):
     def __new__(cls,format_str,*args,**kwargs):
         self = super(FormattedTime,cls).__new__(cls,*args,**kwargs)
-        self.format_str = format_str
-        return self
-
-class FormattedFloat(StrFormattedMixIn,float):
-    def __new__(cls,format_str,*args,**kwargs):
-        self = super(FormattedFloat,cls).__new__(cls,*args,**kwargs)
-        self.format_str = format_str
-        return self
-
-class FormattedInt(StrFormattedMixIn,int):
-    def __new__(cls,format_str,*args,**kwargs):
-        self = super(FormattedInt,cls).__new__(cls,*args,**kwargs)
         self.format_str = format_str
         return self
 
@@ -135,38 +113,6 @@ class FormatterStrBase(FormatterBase):
     def _parseString(self,value):
         """Sub-classes should implement this."""
         raise NotImplementedError
-
-class FloatFormatter(FormatterStrBase):
-    """Formats a float for user interaction.
-       format_str is a Python %-string."""
-
-    FormattedType = FormattedFloat
-    UnformattedType = float
-
-    def _parseUnformattedType(self, value):
-        return FormattedFloat(self.format_str,value)
-
-    def _parseString(self, value):
-        try:
-            return FormattedFloat(self.format_str,value)
-        except (TypeError,ValueError):
-            return None
-
-class IntFormatter(FormatterStrBase):
-    """Formats an int for user interaction.
-       format_str is a Python %-string."""
-
-    FormattedType = FormattedInt
-    UnformattedType = int
-
-    def _parseUnformattedType(self, value):
-        return FormattedInt(self.format_str,value)
-
-    def _parseString(self, value):
-        try:
-            return FormattedInt(self.format_str,value)
-        except (TypeError,ValueError):
-            return None
 
 class DatetimeFormatter(FormatterStrBase):
     """Formats and parses dates for user interaction.

--- a/j5basic/Module.py
+++ b/j5basic/Module.py
@@ -105,8 +105,8 @@ def get_all_distinct_mro_targets(obj, functionname):
         if base_hook_fn:
             t_f = getattr(base_hook_fn, '__func__', None)
             if t_f is None:
-                logging.critical("__func__ was None while trying to find all distinct mro targets for %s on %s, mro was %s" % (functionname, obj, obj.__mro__))
-                continue
+                logging.warning("__func__ was None while trying to find all distinct mro targets for %s on %s, mro was %s" % (functionname, obj, obj.__mro__))
+                t_f = base_hook_fn
 
             if t_f not in sources:
                 sources[t_f] = t

--- a/j5basic/test_DictUtils.py
+++ b/j5basic/test_DictUtils.py
@@ -223,12 +223,6 @@ class TestDictHelpers(object):
 
         DictUtils.assert_dicts_equal(DictUtils.filterdict(d1, {1,2,3}), {1:2, 3:4})
 
-    def test_subtractdicts(self):
-        d1 = {1:2, 3:4, 5:6, 7:8, 9:six.b("10"), 11:six.text_type("12")}
-        d2 = {1:2, 3:5, 5: "6", 11: six.b("12"), 9: six.text_type("11")}
-
-        DictUtils.assert_dicts_equal(DictUtils.subtractdicts(d1, d2), {3:4, 5:6, 7:8, 9: six.b("10")})
-
     def test_merge_dicts(self):
         d1 = {1:2, 3:4, 5:6, 7:8}
         d2 = {3:5, 7:9, 11:13}

--- a/j5basic/test_DictUtils.py
+++ b/j5basic/test_DictUtils.py
@@ -243,8 +243,3 @@ class TestDictHelpers(object):
         DictUtils.assert_dicts_equal(DictUtils.mapdict(td, None, valuemap), {1: 3, 3: 5, 5: 7})
         DictUtils.assert_dicts_equal(DictUtils.mapdict(td, keymap, valuemap), {"1": 3, "3": 5, "5": 7})
 
-    def test_upperkeys(self):
-        td = {six.b("t"):1, six.text_type("u"): 2, None: 3}
-
-        DictUtils.assert_dicts_equal(DictUtils.upperkeys(td), {six.b("T"): 1, six.text_type("U"): 2, None: 3})
-

--- a/j5basic/test_Formatters.py
+++ b/j5basic/test_Formatters.py
@@ -21,21 +21,6 @@ class FormatTestResource(object):
 class TestFormatters(IterativeTester.IterativeTester):
 
     FORMAT_TESTS = {
-        'float': FormatTestResource(Formatters.FloatFormatter("%.2f"),Formatters.FormattedFloat,[
-                    (5.5,"5.50"),
-                    (10.617,"10.62"),
-                    ("5.15","5.15"),
-                    ('foo',None),
-                    (Formatters.FormattedFloat("%.2f",10.2234),"10.22")
-                 ]),
-        'int': FormatTestResource(Formatters.IntFormatter("%03d"),Formatters.FormattedInt,[
-                    (55,"055"),
-                    (101,"101"),
-                    ("515","515"),
-                    ('foo',None),
-                    ('5.5',None),
-                    (Formatters.FormattedInt("%03d",55),"055")
-                 ]),
         'datetime': FormatTestResource(Formatters.DatetimeFormatter("%Y:%m:%d %H:%M:%S"),Formatters.FormattedDatetime,[
                     (datetime.datetime(1993,11,3,12,51,50),"1993:11:03 12:51:50"),
                     ("1994:12:07 13:17:25","1994:12:07 13:17:25"),


### PR DESCRIPTION
I fixed all the tests in Python 2 and Python 3

- It seems like `%` would recursively call `str` causing infinite recursion, in StrFormattedMixin
- I deleted `subtractdicts` because it was broken, complicated and unused
- I deleted `upperkeys` because it was broken and unused
- I needed to base a `native_str` to strftime to get a a test to pass
- The test for `get_all_distinct_mro_targets` was failing a test on Python 3, because we were skipping functions if the didn't have a `__func__` property which seemed unreasonable, so I changed that.