### PR TITLE
Prevent Uid actually having 23 digits

### DIFF
--- a/j5basic/Uid.py
+++ b/j5basic/Uid.py
@@ -38,7 +38,7 @@ def uid_digit_str(base_time=None):
        Generated using the current time (unless specified) and a random integer
        to complete it to 22 digits"""
     base_time = base_time or time.time()
-    return str(int(base_time*10**TIME_PRECISION)) + (RAND_FORMAT % random.randint(1,10**RAND_PRECISION))
+    return str(int(base_time*10**TIME_PRECISION)) + (RAND_FORMAT % random.randint(1,10**RAND_PRECISION-1))
 
 def uid_id_str(base_time=None):
     """Returns a unique string consisting of the prefix ID followed by only digits.


### PR DESCRIPTION
On Linux, there's a million-to-one chance this will have 22 digits.

But magicians have calculated that million-to-one chances crop up nine times out of ten.
(On Windows, there's a 10 billion-to-one chance it'll have 22 digits)

PS I actually hit this error on startup and it stopped the server like a Gloadby Marwood