### PR TITLE
Remove virtualtime

### DIFF
--- a/j5basic/DictUtils.py
+++ b/j5basic/DictUtils.py
@@ -14,10 +14,7 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import *
 
-try:
-    from virtualtime import datetime_tz
-except ImportError as e:
-    datetime_tz = None
+import datetime_tz
 
 import datetime
 

--- a/j5basic/TimeUtils.py
+++ b/j5basic/TimeUtils.py
@@ -7,7 +7,7 @@ standard_library.install_aliases()
 from builtins import *
 from past.utils import old_div
 from j5basic import TzInfo
-from virtualtime import datetime_tz, _underlying_datetime_type
+import datetime_tz
 import datetime
 import threading
 import time
@@ -29,7 +29,6 @@ def localminutenow():
     """Provides the current local time with seconds and microseconds set to 0."""
     return datetime_tz.datetime_tz.now().replace(second=0,microsecond=0)
 
-# NB: There is a copy of totalseconds_float in virtualtime, to prevent circular imports - changes should be applied to both
 def totalseconds_float(timedelta):
     """Return the total number of seconds represented by a datetime.timedelta object, including fractions of seconds"""
     return timedelta.seconds + (timedelta.days * 24 * 60 * 60) + timedelta.microseconds/1000000.0
@@ -121,7 +120,7 @@ def _findall(text, substr):
 
 _NEEDS_STRFTIME_PATCH = True
 try:
-    _underlying_datetime_type(1,1,1).strftime("%Y-%m-%d")
+    datetime.datetime(1,1,1).strftime("%Y-%m-%d")
     _NEEDS_STRFTIME_PATCH = False
 except ValueError:
     pass

--- a/j5basic/Timer.py
+++ b/j5basic/Timer.py
@@ -9,11 +9,10 @@ standard_library.install_aliases()
 from builtins import *
 from builtins import object
 from past.utils import old_div
-from virtualtime import datetime_tz
+import datetime_tz
 import logging
 import time
 import threading
-import virtualtime
 from j5basic import Errors
 
 def to_seconds(timedelta):
@@ -25,8 +24,6 @@ class Timer(object):
     def __init__(self, target, args=None, kwargs=None, resolution=1):
         self.interrupt_event = threading.Event()
         self.virtual_time_callback_event = threading.Event()
-        virtualtime.notify_on_change(self.interrupt_event)
-        virtualtime.wait_for_callback_on_change(self.virtual_time_callback_event)
         self._running = True
         self.target = target
         self.args = args
@@ -68,8 +65,6 @@ class Timer(object):
                     self.interrupt_event.wait(waitseconds)
                     self.interrupt_event.clear()
                     currenttime = datetime_tz.datetime_tz.now()
-                    if virtualtime.in_skip_time_change():
-                        nexttime = currenttime.replace(microsecond=0)
                 if self._running and nexttime <= currenttime:
                     self.setup_run(nexttime)
                     self.virtual_time_callback_event.set()

--- a/j5basic/test_TimeCache.py
+++ b/j5basic/test_TimeCache.py
@@ -121,13 +121,13 @@ class TestTimeCache(object):
         d[0] = datetime.datetime.now()
         d[1] = datetime.datetime.now()
         assert len(d) == 2
-        time.sleep(2)
+        time.sleep(2.2)
         assert len(d) == 2
         d.set(2, datetime.datetime.now())
         assert len(d) == 1
-        time.sleep(1)
+        time.sleep(1.1)
         d[3] = datetime.datetime.now()
-        time.sleep(1)
+        time.sleep(1.1)
         d[4] = datetime.datetime.now()
         assert len(d) == 1
         d.clear()
@@ -138,7 +138,7 @@ class TestTimeCache(object):
         d[1] = datetime.datetime.now()
         assert d.get(0)
         assert len(d) == 2
-        time.sleep(2)
+        time.sleep(2.2)
         assert d.get(0) is None
         assert raises(KeyError, lambda: d[0])
         assert not d.has_key(1)
@@ -151,7 +151,7 @@ class TestTimeCache(object):
         assert list(d.items())[0][0] == 2
         assert list(d.keys()) == [2]
         assert list(d.values())
-        time.sleep(1)
+        time.sleep(1.1)
         assert list(d) == []
         d[3] = datetime.datetime.now()
         assert d.popitem()[0] == 3

--- a/j5basic/test_Timer.py
+++ b/j5basic/test_Timer.py
@@ -11,8 +11,6 @@ from builtins import *
 from builtins import object
 from j5basic import Timer
 from j5test import Utils
-import virtualtime
-from virtualtime import test_virtualtime
 import threading
 import time
 
@@ -100,7 +98,7 @@ class TestTimer(object):
         timer = Timer.Timer(tm.sleepfunc, args=(iter([0,2,3,0,6]),))
         thread = threading.Thread(target=timer.start)
         thread.start()
-        start_time = virtualtime._original_time()
+        start_time = time.time()
         # make sure our sleep happens within the last 6-second pause
         self.sleep(12)
         print(time.time(), tm.lasttime)
@@ -130,15 +128,4 @@ class TestTimer(object):
         timer.stop = True
         assert tm.lasttime is None
         self.finish_wait(thread, tm.errors)
-
-class TestVirtualTimer(TestTimer, test_virtualtime.RunPatched):
-    """Tests that Timers react appropriately to virtual time setting"""
-    def sleep(self, seconds):
-        virtualtime.fast_forward_time(seconds)
-
-    def finish_wait(self, thread, error_list, expected_sleep=0):
-        """Waits for the thread to finish, checks for any errors in the given list. expected_sleep says how long we should have to wait for this..."""
-        if expected_sleep:
-            virtualtime.fast_forward_time(expected_sleep)
-        super(TestVirtualTimer, self).finish_wait(thread, error_list, expected_sleep)
 

--- a/j5basic/test_WithContextSkip_cpython.py
+++ b/j5basic/test_WithContextSkip_cpython.py
@@ -11,7 +11,6 @@ import sys
 import tempfile
 import unittest
 from j5basic.WithContextSkip import *  # Tests __all__
-from test import support as test_support
 try:
     import threading
 except ImportError:
@@ -112,10 +111,3 @@ class ConditionalContextManagerTestCase(unittest.TestCase):
     def test_contextmanager_doc_attrib(self):
         baz = self._create_contextmanager_attribs()
         self.assertEqual(baz.__doc__, "Whee!")
-
-# This is needed to make the test actually run under regrtest.py!
-def test_main():
-    test_support.run_unittest(__name__)
-
-if __name__ == "__main__":
-    test_main()


### PR DESCRIPTION
I'm removing `virtualtime` from the code and the tests, as it's quite complex and difficult to maintain. It also monkey patches the `datetime` and `time` libraries to fix things which are no longer problems on python 3. I've also changed the sleeps in test_TimeCache.py to be slightly longer, so that they actually reliably pass. Waiting for the exact amount of time that TimeCache was set to expire in, meant that they'd only sometimes pass for me.

On python 2, all the unit tests seem to pass reliably:
![image](https://user-images.githubusercontent.com/1752608/84894573-4ca00480-b0a1-11ea-83c2-48a59b40780a.png)

On python 3, one fails, and only passes intermittently:
![image](https://user-images.githubusercontent.com/1752608/84894634-64778880-b0a1-11ea-9d7f-583fc00fec3b.png)

Looking at the test, I don't see how it was passing reliably before. It relies on somehow stopping a timer before it's managed to run once.

I've also run j5 in both python 2 and 3 with these changes, without any issue.