### PR TITLE
Update getargspec

### DIFF
--- a/j5basic/API.py
+++ b/j5basic/API.py
@@ -30,6 +30,7 @@ from builtins import *
 from builtins import object
 from future.utils import PY3
 import inspect
+from j5basic.Decorators import getargspec
 
 if not PY3:
     INSPECT_METHOD = inspect.ismethod
@@ -75,9 +76,9 @@ class APIMeta(type):
                     continue
                 if not hasattr(new_class, method):
                     raise APIError("Class %s does not implement method %s from API %s" % (new_class, method, interface))
-                interface_spec = inspect.getfullargspec(interface_method)
-                new_class_spec = inspect.getfullargspec(getattr(new_class, method))
-                if interface_spec[:4] != new_class_spec[:4]:  # [:4] to match old getargspec
+                interface_spec = getargspec(interface_method)
+                new_class_spec = getargspec(getattr(new_class, method))
+                if interface_spec != new_class_spec:
                     raise APIError("Class %s has a different signature for method %s from the declaration in API %s" % (new_class, method, interface))
         return new_class
 

--- a/j5basic/API.py
+++ b/j5basic/API.py
@@ -75,9 +75,9 @@ class APIMeta(type):
                     continue
                 if not hasattr(new_class, method):
                     raise APIError("Class %s does not implement method %s from API %s" % (new_class, method, interface))
-                interface_spec = inspect.getargspec(interface_method)
-                new_class_spec = inspect.getargspec(getattr(new_class, method))
-                if interface_spec != new_class_spec:
+                interface_spec = inspect.getfullargspec(interface_method)
+                new_class_spec = inspect.getfullargspec(getattr(new_class, method))
+                if interface_spec[:4] != new_class_spec[:4]:  # [:4] to match old getargspec
                     raise APIError("Class %s has a different signature for method %s from the declaration in API %s" % (new_class, method, interface))
         return new_class
 

--- a/j5basic/Converters.py
+++ b/j5basic/Converters.py
@@ -7,6 +7,20 @@ standard_library.install_aliases()
 from builtins import *
 from builtins import object
 import logging
+from typing import NamedTuple
+from inspect import FullArgSpec
+
+
+SmallArgSpec = NamedTuple("SmallArgSpec", [("args", list), ("varargs", str), ("keywords", str), ("defaults", list)])
+
+def convert_arg_spec(full_argspec: FullArgSpec) -> SmallArgSpec:
+    return SmallArgSpec(
+        args=full_argspec.args,
+        varargs=full_argspec.varargs,
+        keywords=full_argspec.varkw,
+        defaults=full_argspec.defaults
+    )
+
 
 class Converter(object):
     string_unit_dict = {} # override in child

--- a/j5basic/Decorators.py
+++ b/j5basic/Decorators.py
@@ -42,7 +42,7 @@ def getrightargs(function, args):
             return {}
         else:
             function = function.__init__
-    argnames, varargs, varkw, defaults = inspect.getargspec(function)
+    argnames, varargs, varkw, defaults, *_ = inspect.getfullargspec(function)
     if varkw == None:   # Can't accept random keywords
         newdict = {}
         for arg in argnames:
@@ -76,7 +76,7 @@ class decorator_helpers(object):
            - arg0 ... argn (shortcuts for the names of the arguments)"""
 
         assert inspect.ismethod(func) or inspect.isfunction(func) or isinstance(func, classmethod), "getinfo can only be used with a function or class method"
-        regargs, varargs, varkwargs, defaults = inspect.getargspec(func)
+        regargs, varargs, varkwargs, defaults, *_ = inspect.getfullargspec(func)
         if extendedargs:
             if defaults is None:
                 defaults = []

--- a/j5basic/Decorators.py
+++ b/j5basic/Decorators.py
@@ -43,7 +43,7 @@ def getrightargs(function, args):
             return {}
         else:
             function = function.__init__
-    argnames, varargs, varkw, defaults, *_ = inspect.getfullargspec(function)
+    argnames, varargs, varkw, defaults = getargspec(function)
     if varkw == None:   # Can't accept random keywords
         newdict = {}
         for arg in argnames:
@@ -136,7 +136,7 @@ class decorator_helpers(object):
            - arg0 ... argn (shortcuts for the names of the arguments)"""
 
         assert inspect.ismethod(func) or inspect.isfunction(func) or isinstance(func, classmethod), "getinfo can only be used with a function or class method"
-        regargs, varargs, varkwargs, defaults, *_ = inspect.getfullargspec(func)
+        regargs, varargs, varkwargs, defaults = getargspec(func)
         if extendedargs:
             if defaults is None:
                 defaults = []

--- a/j5basic/test_Decorators.py
+++ b/j5basic/test_Decorators.py
@@ -57,7 +57,7 @@ class TestDecoratorDecorator(object):
 
     @staticmethod
     def override_x(f, *args, **kw):
-        args, kw = Decorators.override_arg("x", 50, args, kw, inspect.getargspec(f))
+        args, kw = Decorators.override_arg("x", 50, args, kw, inspect.getfullargspec(f)[:4])
         return f(*args, **kw)
 
     @staticmethod
@@ -337,7 +337,7 @@ def test_get_right_args():
     rightargs = Decorators.getrightargs(my_arg_class, {'foo': 1, 'bar': 2, 'bob': 3, 'mary': 4})
     DictUtils.assert_dicts_equal(rightargs, {'foo': 1, 'filip': None})
 
-    rightargs, rightkw = Decorators.conform_to_argspec((1, 2), {'billybob': 5, 'jim': 3}, inspect.getargspec(my_arg_function))
+    rightargs, rightkw = Decorators.conform_to_argspec((1, 2), {'billybob': 5, 'jim': 3}, inspect.getfullargspec(my_arg_function)[:4])
     assert rightargs == [1, 2, 3]
     assert not rightkw
 
@@ -348,15 +348,15 @@ def test_get_or_pop_arg():
     args = (1, 2)
     kw = {'jim': 3}
 
-    assert Decorators.get_or_pop_arg('bar', args, kw, inspect.getargspec(my_arg_function)) == 2
+    assert Decorators.get_or_pop_arg('bar', args, kw, inspect.getfullargspec(my_arg_function)[:4]) == 2
     assert args == (1, 2)
     DictUtils.assert_dicts_equal(kw, {'jim': 3})
-    assert Decorators.get_or_pop_arg('jim', args, kw, inspect.getargspec(my_arg_function)) == 3
+    assert Decorators.get_or_pop_arg('jim', args, kw, inspect.getfullargspec(my_arg_function)[:4]) == 3
     assert args == (1, 2)
     DictUtils.assert_dicts_equal(kw, {'jim': 3})
 
     kw['billybob'] = 4
-    assert Decorators.get_or_pop_arg('billybob', args, kw, inspect.getargspec(my_arg_function)) == 4
+    assert Decorators.get_or_pop_arg('billybob', args, kw, inspect.getfullargspec(my_arg_function)[:4]) == 4
     assert args == (1, 2)
     DictUtils.assert_dicts_equal(kw, {'jim': 3})
 

--- a/j5basic/test_Decorators.py
+++ b/j5basic/test_Decorators.py
@@ -15,6 +15,7 @@ import threading
 import time
 import inspect
 from j5test.Utils import method_raises, raises
+from j5basic.Decorators import getargspec
 
 class TestDecoratorDecorator(object):
 
@@ -57,7 +58,7 @@ class TestDecoratorDecorator(object):
 
     @staticmethod
     def override_x(f, *args, **kw):
-        args, kw = Decorators.override_arg("x", 50, args, kw, inspect.getfullargspec(f)[:4])
+        args, kw = Decorators.override_arg("x", 50, args, kw, getargspec(f))
         return f(*args, **kw)
 
     @staticmethod
@@ -337,7 +338,7 @@ def test_get_right_args():
     rightargs = Decorators.getrightargs(my_arg_class, {'foo': 1, 'bar': 2, 'bob': 3, 'mary': 4})
     DictUtils.assert_dicts_equal(rightargs, {'foo': 1, 'filip': None})
 
-    rightargs, rightkw = Decorators.conform_to_argspec((1, 2), {'billybob': 5, 'jim': 3}, inspect.getfullargspec(my_arg_function)[:4])
+    rightargs, rightkw = Decorators.conform_to_argspec((1, 2), {'billybob': 5, 'jim': 3}, getargspec(my_arg_function))
     assert rightargs == [1, 2, 3]
     assert not rightkw
 
@@ -348,15 +349,15 @@ def test_get_or_pop_arg():
     args = (1, 2)
     kw = {'jim': 3}
 
-    assert Decorators.get_or_pop_arg('bar', args, kw, inspect.getfullargspec(my_arg_function)[:4]) == 2
+    assert Decorators.get_or_pop_arg('bar', args, kw, getargspec(my_arg_function)) == 2
     assert args == (1, 2)
     DictUtils.assert_dicts_equal(kw, {'jim': 3})
-    assert Decorators.get_or_pop_arg('jim', args, kw, inspect.getfullargspec(my_arg_function)[:4]) == 3
+    assert Decorators.get_or_pop_arg('jim', args, kw, getargspec(my_arg_function)) == 3
     assert args == (1, 2)
     DictUtils.assert_dicts_equal(kw, {'jim': 3})
 
     kw['billybob'] = 4
-    assert Decorators.get_or_pop_arg('billybob', args, kw, inspect.getfullargspec(my_arg_function)[:4]) == 4
+    assert Decorators.get_or_pop_arg('billybob', args, kw, getargspec(my_arg_function)) == 4
     assert args == (1, 2)
     DictUtils.assert_dicts_equal(kw, {'jim': 3})
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='j5basic',
-    version='1.4',
+    version='1.5',
     packages=['j5basic'],
     license='Apache License, Version 2.0',
     description='A collection of utility methods and classes.',


### PR DESCRIPTION
Added new getargspec function that returns a smaller argspec object based on what is returned from getfullargspec.

Copied formatargspec from inspect on python 3.9 as it is the safer option than reimplementing the same behaviour.